### PR TITLE
[GST-2291] Adds a https flag to nodesource repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
     - master
 
 language: python
+
+services: []
+
 python:
   - "2.7"
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,31 @@ Simply install latest LTS version.
         version: 4
 ```
 
+Turn off https for repo sources:
+
+```YAML
+- name: Install Node.js
+  hosts: sandbox
+
+  pre_tasks:
+    - name: Update apt
+      become: yes
+      apt:
+        cache_valid_time: 1800
+        update_cache: yes
+      tags:
+        - build
+
+  roles:
+    - role: sansible.nodejs
+      nodejs:
+        emergency_switch_to_http_sources: true
+        version: 4
+```
+
+Nodesource have had several SSL issues recently, use this flag to switch to http in case of an emergency.
+
+
 
 
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
 nodejs:
+  emergency_switch_to_http_sources: false
   # 4 or 5
   version: 4

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -15,7 +15,7 @@
 - name: Add NodeSource deb repository
   become: yes
   apt_repository:
-    repo: "deb https://deb.nodesource.com/node_{{ nodejs.version }}.x {{ ansible_distribution_release }} main"
+    repo: "deb {{ 'http' if nodejs.emergency_switch_to_http_sources | bool else 'https' }}://deb.nodesource.com/node_{{ nodejs.version }}.x {{ ansible_distribution_release }} main"
     state: present
 
 - name: Install Node.js


### PR DESCRIPTION
There is an issue with the Nodesource SSL certs at the moment, to
get around this we can temporarily turn off https on their repos
until the issue is resolved.